### PR TITLE
Port to preCICE v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.exe
 *.log
 *.pyc
+*.so
 .cproject
 .project
 .sconsign.dblite
@@ -11,3 +12,10 @@
 \#*#
 core
 tests/test_fluent
+Makefile
+src/makefile
+lnamd64/2d_node/makefile
+lnamd64/2d_host/makefile
+lnamd64/2d_node/makelog
+lnamd64/2d_host/makelog
+*.sh

--- a/src/fsi.c
+++ b/src/fsi.c
@@ -101,7 +101,7 @@ void fsi_init(Domain* domain)
     did_gather_write_positions = BOOL_TRUE;
     did_gather_read_positions = BOOL_TRUE;
     skip_grid_motion = BOOL_FALSE; /* Read local displacements not stored in fluent checkpoint */
-    precicec_fulfilledAction(precicec_actionReadSimulationCheckpoint());
+    precicec_markActionFulfilled(precicec_actionReadSimulationCheckpoint());
   }
 
   if (precicec_isActionRequired(precicec_actionWriteIterationCheckpoint())){
@@ -110,7 +110,7 @@ void fsi_init(Domain* domain)
     RP_Set_Integer("udf/convergence", BOOL_FALSE);
     RP_Set_Integer("udf/iterate", BOOL_TRUE);
     #endif /* ! RP_NODE */
-    precicec_fulfilledAction(precicec_actionWriteIterationCheckpoint());
+    precicec_markActionFulfilled(precicec_actionWriteIterationCheckpoint());
   }
   else {
     Message("  (%d) Explicit coupling\n", myid);
@@ -164,14 +164,14 @@ void fsi_write_and_advance()
     #if !RP_NODE
     RP_Set_Integer("udf/convergence", BOOL_TRUE);
     #endif /* !RP_NODE */
-    precicec_fulfilledAction(precicec_actionWriteIterationCheckpoint());
+    precicec_markActionFulfilled(precicec_actionWriteIterationCheckpoint());
   }
 
   if (precicec_isActionRequired(precicec_actionReadIterationCheckpoint())){
     #if !RP_NODE
     RP_Set_Integer("udf/convergence", BOOL_FALSE);
     #endif /* !RP_NODE */
-    precicec_fulfilledAction(precicec_actionReadIterationCheckpoint());
+    precicec_markActionFulfilled(precicec_actionReadIterationCheckpoint());
   }
 
   #if !RP_NODE
@@ -181,7 +181,7 @@ void fsi_write_and_advance()
   #endif /* !RP_NODE */
 
   if (precicec_isActionRequired(precicec_actionWriteSimulationCheckpoint())){
-    precicec_fulfilledAction(precicec_actionWriteSimulationCheckpoint());
+    precicec_markActionFulfilled(precicec_actionWriteSimulationCheckpoint());
     require_create_checkpoint = BOOL_TRUE;
     #if !RP_NODE
     Message("  (%d) Writing simulation checkpoint required\n", myid);

--- a/src/fsi.c
+++ b/src/fsi.c
@@ -93,17 +93,6 @@ void fsi_init(Domain* domain)
   count_dynamic_threads();
   #endif /* ! RP_HOST */
 
-  if (precicec_isActionRequired(precicec_actionReadSimulationCheckpoint())){
-    #if !RP_NODE /* HOST or SERIAL */
-    Message("  (%d) Reading simulation checkpoint required\n", myid);
-    RP_Set_Integer("udf/checkpoint", BOOL_TRUE);
-    #endif /* !RP_NODE */
-    did_gather_write_positions = BOOL_TRUE;
-    did_gather_read_positions = BOOL_TRUE;
-    skip_grid_motion = BOOL_FALSE; /* Read local displacements not stored in fluent checkpoint */
-    precicec_markActionFulfilled(precicec_actionReadSimulationCheckpoint());
-  }
-
   if (precicec_isActionRequired(precicec_actionWriteIterationCheckpoint())){
     Message("  (%d) Implicit coupling\n", myid);
     #if ! RP_NODE
@@ -180,14 +169,6 @@ void fsi_write_and_advance()
   }
   #endif /* !RP_NODE */
 
-  if (precicec_isActionRequired(precicec_actionWriteSimulationCheckpoint())){
-    precicec_markActionFulfilled(precicec_actionWriteSimulationCheckpoint());
-    require_create_checkpoint = BOOL_TRUE;
-    #if !RP_NODE
-    Message("  (%d) Writing simulation checkpoint required\n", myid);
-    RP_Set_Integer("udf/checkpoint", BOOL_TRUE);
-    #endif /* !RP_NODE */
-  }
   #if !RP_NODE
   else {
     RP_Set_Integer("udf/checkpoint", BOOL_FALSE);


### PR DESCRIPTION
This PR encapsulates multiple changes to port the adapter to preCICE v2. See the [migration guide for more details](https://github.com/precice/precice/wiki/Porting-adapters-from-preCICE-1.x-to-2.x).

It also fixes a minor warning of some compilers.