### PR TITLE
Files Updated for Fluent and preCICE `v3.0.0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ step through UDF code line-by-line are found [here](https://www.cfd-online.com/W
 
 ## Development history
 
-The initial version of this adapter was developed by Bernhard Gatzhammer during the work on his thesis [1].
+The initial version of this adapter was developed by Bernhard Gatzhammer as part of his doctoral dissertation [1].
 
 [Richard Hertrich](https://github.com/richahert) [2] and [Ishaan Desai](https://www.ipvs.uni-stuttgart.de/institute/team/Desai/) worked on the adapter in the scope of their work under supervision of [Benjamin Rodenberg](https://www.cs.cit.tum.de/sccs/personen/benjamin-rodenberg/).
 

--- a/README.md
+++ b/README.md
@@ -181,6 +181,14 @@ All ANSYS packages are installed in a folder `ansys_inc/` at the location define
 UDFs can be difficult to debug because they are interpreted within Fluent. Sometimes this leads to misleading statements and tracebacks upon crashing. Some instructions on how to use gdb to
 step through UDF code line-by-line are found [here](https://www.cfd-online.com/Wiki/Udf_debug).
 
+## Development history
+
+The initial version of this adapter was developed by Bernhard Gatzhammer during the work on his thesis [1].
+
+[Richard Hertrich](https://github.com/richahert) [2] and [Ishaan Desai](https://www.ipvs.uni-stuttgart.de/institute/team/Desai/) worked on the adapter in the scope of their work under supervision of [Benjamin Rodenberg](https://www.cs.cit.tum.de/sccs/personen/benjamin-rodenberg/).
+
+Mike Tree contributed a [considerable update of the adapter](https://github.com/precice/fluent-adapter/pull/24).
+
 ## References
 
 [1] Gatzhammer, Bernhard. Efficient and Flexible Partitioned Simulation of Fluid-Structure Interactions. PhD Thesis, Department of Informatics, Technical University of Munich, 2014.


### PR DESCRIPTION
Fix: updated README file with the recent instructions for Fluent 23R2 and instructions for generating the makefile
Fix: updated precice-config, fsi.c and CSMdummy to match precice3
Fix: steer-fluent.txt in now working according to our example with updated paths